### PR TITLE
Restrict Repos to member repos only and updated response attribute

### DIFF
--- a/gitlab-repo-dl.sh
+++ b/gitlab-repo-dl.sh
@@ -41,8 +41,8 @@ if [ "$1" == "group" ]; then
     done
 elif [ "$1" == "all-repo-list" ]; then
     # Get total number of pages (with 20 projects per page) from HTTP header
-    TOTAL_PAGES=`curl "$GITLAB_URL/api/v4/projects?private_token=$GITLAB_TOKEN&membership=true" -sI | grep x-total-pages | awk '{print $2}' | sed 's/\\r//g'`
-    
+    TOTAL_PAGES=`curl "$GITLAB_URL/api/v4/projects?private_token=$GITLAB_TOKEN&membership=true" -sI | grep X-Total-Pages | awk '{print $2}' | sed 's/\\r//g'`
+     
     for ((PAGE_NUMBER = 1; PAGE_NUMBER <= TOTAL_PAGES; PAGE_NUMBER++)); do
         # echo git@instance:namespace/repo.git
         curl "$GITLAB_URL/api/v4/projects?private_token=$GITLAB_TOKEN&per_page=20&page=$PAGE_NUMBER&membership=true" | jq '.[] | .ssh_url_to_repo' | sed 's/"//g'

--- a/gitlab-repo-dl.sh
+++ b/gitlab-repo-dl.sh
@@ -41,7 +41,7 @@ if [ "$1" == "group" ]; then
     done
 elif [ "$1" == "all-repo-list" ]; then
     # Get total number of pages (with 20 projects per page) from HTTP header
-    TOTAL_PAGES=`curl "$GITLAB_URL/api/v4/projects?private_token=$GITLAB_TOKEN&membership=true" -sI | grep X-Total-Pages | awk '{print $2}' | sed 's/\\r//g'`
+    TOTAL_PAGES=`curl "$GITLAB_URL/api/v4/projects?private_token=$GITLAB_TOKEN&membership=true" -sI | grep x-total-pages | awk '{print $2}' | sed 's/\\r//g'`
      
     for ((PAGE_NUMBER = 1; PAGE_NUMBER <= TOTAL_PAGES; PAGE_NUMBER++)); do
         # echo git@instance:namespace/repo.git

--- a/gitlab-repo-dl.sh
+++ b/gitlab-repo-dl.sh
@@ -7,7 +7,7 @@ fi
 
 if [ -z "$GITLAB_TOKEN" ]; then
     echo "Missing environment variable: GITLAB_TOKEN"
-    echo "See ${GITLAB_URL}profile/account."
+    echo "See ${GITLAB_URL}/profile/account."
     exit 1
 fi
 
@@ -41,11 +41,11 @@ if [ "$1" == "group" ]; then
     done
 elif [ "$1" == "all-repo-list" ]; then
     # Get total number of pages (with 20 projects per page) from HTTP header
-    TOTAL_PAGES=`curl "$GITLAB_URL/api/v4/projects?private_token=$GITLAB_TOKEN" -sI | grep X-Total-Pages | awk '{print $2}' | sed 's/\\r//g'`
-
+    TOTAL_PAGES=`curl "$GITLAB_URL/api/v4/projects?private_token=$GITLAB_TOKEN&membership=true" -sI | grep x-total-pages | awk '{print $2}' | sed 's/\\r//g'`
+    
     for ((PAGE_NUMBER = 1; PAGE_NUMBER <= TOTAL_PAGES; PAGE_NUMBER++)); do
         # echo git@instance:namespace/repo.git
-        curl "$GITLAB_URL/api/v4/projects?private_token=$GITLAB_TOKEN&per_page=20&page=$PAGE_NUMBER" | jq '.[] | .ssh_url_to_repo' | sed 's/"//g'
+        curl "$GITLAB_URL/api/v4/projects?private_token=$GITLAB_TOKEN&per_page=20&page=$PAGE_NUMBER&membership=true" | jq '.[] | .ssh_url_to_repo' | sed 's/"//g'
     done
 elif [ "$1" == "from-list" ]; then
     if [ -z "$2" ]; then


### PR DESCRIPTION
Newer gitlab instances respond with lowercase attributes. Also to not get all public repos as well I restricted the list to member repos only